### PR TITLE
Aggregate duration for lifecycle phases

### DIFF
--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -20,6 +20,8 @@ package com.soebes.maven.extensions;
  */
 
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -433,11 +435,9 @@ public class BuildTimeProfiler
         for ( String phase : lifeCyclePhases )
         {
             LOGGER.info( "{}:", phase );
-            Map<ProjectMojo, SystemTime> plugisInPhase = mojoTimer.getPluginsInPhase( phase );
-            for ( Entry<ProjectMojo, SystemTime> pluginInPhase : plugisInPhase.entrySet() )
-            {
-                LOGGER.info( "{} ms: {}", String.format( "%8d", pluginInPhase.getValue().getElapsedTime() ),
-                             pluginInPhase.getKey().getMojo().getFullId() );
+            List<Entry<String, Long>> durationsByPlugin = aggregateDurations( mojoTimer.getPluginsInPhase(phase) );
+            for ( Entry<String, Long> durationByPlugin : durationsByPlugin ) {
+                LOGGER.info("{} ms: {}", String.format( "%8d", durationByPlugin.getValue()), durationByPlugin.getKey() );
             }
         }
         LOGGER.info( "------------------------------------------------------------------------" );
@@ -466,4 +466,24 @@ public class BuildTimeProfiler
         }
     }
 
+    private List<Entry<String, Long>> aggregateDurations( Map<ProjectMojo, SystemTime> pluginsInPhase ) {
+        Map<String, Long> durationsByPlugin = new HashMap<>( pluginsInPhase.size() );
+        for ( Entry<ProjectMojo, SystemTime> pluginInPhase : pluginsInPhase.entrySet() ) {
+            String pluginId = pluginInPhase.getKey().getMojo().getFullId();
+            Long oldDuration = durationsByPlugin.containsKey( pluginId ) ? durationsByPlugin.get( pluginId ) : 0L;
+            Long newDuration = oldDuration + pluginInPhase.getValue().getElapsedTime();
+            durationsByPlugin.put( pluginId, newDuration );
+        }
+
+        // sort the entries according to the duration (descending)
+        List<Entry<String, Long>> orderedList = new LinkedList<>();
+        orderedList.addAll( durationsByPlugin.entrySet() );
+        Collections.sort( orderedList, new Comparator<Entry<String, Long>>() {
+             public int compare( Entry<String, Long> o1, Entry<String, Long> o2 ) {
+                return o2.getValue().compareTo( o1.getValue() );
+             }
+        } );
+        
+        return orderedList;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -377,9 +377,20 @@ public class BuildTimeProfiler
 
     private void executionResultEventHandler( MavenExecutionResult event )
     {
-        LOGGER.debug( "MBTP: executionResultEventHandler: {}", event.getProject() );
+    	// when no phase was built, do not create any statistics
+    	if (lifeCyclePhases.isEmpty() || lifeCyclePhases.get(0) == null) {
+    		return;
+    	}
+
+    	// sort the information for Maven phases according to their order in the lifecycle 
+    	Collections.sort(lifeCyclePhases, new LifeCyclePhaseComparator());
+
+    	LOGGER.debug( "MBTP: executionResultEventHandler: {}", event.getProject() );
 
         // TODO: Use better formatting
+        LOGGER.info( "" );
+        LOGGER.info( "" );
+        LOGGER.info( "------------------------------------------------------------------------" );
         LOGGER.info( "--             Maven Build Time Profiler Summary                      --" );
         LOGGER.info( "------------------------------------------------------------------------" );
 
@@ -402,9 +413,7 @@ public class BuildTimeProfiler
 
                 long timeForPhaseAndProjectInMillis = mojoTimer.getTimeForProjectAndPhaseInMillis( proKey, phase );
                 LOGGER.info( "    {} ms : {}", String.format( "%8d", timeForPhaseAndProjectInMillis ), phase );
-
             }
-
         }
 
         // LifecyclePhase.CLEAN.ordinal();
@@ -430,7 +439,6 @@ public class BuildTimeProfiler
                 LOGGER.info( "{} ms: {}", String.format( "%8d", pluginInPhase.getValue().getElapsedTime() ),
                              pluginInPhase.getKey().getMojo().getFullId() );
             }
-
         }
         LOGGER.info( "------------------------------------------------------------------------" );
 

--- a/src/main/java/com/soebes/maven/extensions/LifeCyclePhaseComparator.java
+++ b/src/main/java/com/soebes/maven/extensions/LifeCyclePhaseComparator.java
@@ -1,0 +1,49 @@
+package com.soebes.maven.extensions;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Compares two Maven life cycle phases (given as Strings) for order, which in
+ * this case is the order in that the phases are executed by Maven (see
+ * <code>http://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html</code>).
+ * In addition, we assume following order of built-in life cycles:
+ * <code>clean</code>, <code>default</code>, <code>site</code>. Custom life
+ * cycles or phases are considered to be of highest order.
+ * 
+ * @author Christoph Amshoff
+ */
+public class LifeCyclePhaseComparator implements Comparator<String> {
+
+	private static Map<String, Integer> phaseOrderMap = new HashMap<>();
+
+	static {
+		// Clean Lifecycle
+		addPhasesInOrder(1, "pre-clean", "clean", "post-clean");
+
+		// Default Lifecycle
+		addPhasesInOrder(10, "validate", "initialize", "generate-sources", "process-sources", "generate-resources",
+				"process-resources", "compile", "process-classes", "generate-test-sources", "process-test-sources",
+				"generate-test-resources", "process-test-resources", "test-compile", "process-test-classes", "test",
+				"prepare-package", "package", "pre-integration-test", "integration-test", "post-integration-test",
+				"verify", "install", "deploy");
+
+		// Site Lifecycle
+		addPhasesInOrder(50, "pre-site", "site", "post-site", "site-deploy");
+	}
+
+	@Override
+	public int compare(String phase1, String phase2) {
+		int order1 = phaseOrderMap.containsKey(phase1) ? phaseOrderMap.get(phase1) : 99;
+		int order2 = phaseOrderMap.containsKey(phase2) ? phaseOrderMap.get(phase2) : 99;
+		return Integer.compare(order1, order2);
+	}
+
+	private static void addPhasesInOrder(int startOrdinalNumber, String... phases) {
+		int ordinalNumber = startOrdinalNumber;
+		for (String phase : phases) {
+			phaseOrderMap.put(phase, ordinalNumber++);
+		}
+	}
+}


### PR DESCRIPTION
For multi-module projects, the ouput section "Plugins in lifecycle Phases" lists each single plugin execution per phase with associated duration:

```
[INFO] package:
[INFO]       12 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:jar:default-jar
[INFO]        1 ms: org.apache.maven.plugins:maven-site-plugin:3.4:attach-descriptor:attach-descriptor
[INFO]       18 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:test-jar:test-jar
[INFO]        1 ms: org.apache.maven.plugins:maven-site-plugin:3.4:attach-descriptor:attach-descriptor
[INFO]       39 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:jar:default-jar
[INFO]       34 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:jar:default-jar
[INFO]       73 ms: org.apache.maven.plugins:maven-dependency-plugin:2.10:copy-dependencies:copy-dependencies
[INFO]        1 ms: org.apache.maven.plugins:maven-site-plugin:3.4:attach-descriptor:attach-descriptor
[INFO]      240 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:jar:default-jar
...
```

I think this output can be improved with my changes, by aggregating the execution times for each plugin for all executions, and show them in descending order:

```
[INFO] package:
[INFO]    19839 ms: org.apache.maven.plugins:maven-assembly-plugin:2.5.5:single:make-assembly
[INFO]     1288 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:jar:default-jar
[INFO]      856 ms: org.apache.maven.plugins:maven-jar-plugin:2.6:test-jar:test-jar
[INFO]      718 ms: org.apache.maven.plugins:maven-site-plugin:3.4:attach-descriptor:attach-descriptor
[INFO]       54 ms: org.apache.maven.plugins:maven-dependency-plugin:2.10:copy-dependencies:copy-dependencies
```
