### PR TITLE
Use latest released version in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ have to define the following `.mvn/extensions.xml` file:
   <extension>
     <groupId>com.soebes.maven.extensions</groupId>
     <artifactId>maven-buildtime-profiler</artifactId>
-    <version>0.2.0</version>
+    <version>0.1.0</version>
   </extension>
 </extensions>
 ```


### PR DESCRIPTION
By searching maven central and inspecting the current version on master (which is 0.1.1-SNAPSHOT) I assume there is no released version of 0.2.0. This PR fixes the getting started documentation which doesn't work when targeting 0.2.0.