### PR TITLE
#5 Allow printing report to a JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ target
 .project
 .classpath
 .settings
+# IDEA generated
+.idea
 # Release plugin
 release.properties
 # TestNG within Eclipse.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ have to define the following `.mvn/extensions.xml` file:
 
 The download from Maven Central will be done by Maven itself.
 
+This extension allows printing the report to a JSON file instead of the stdout. To enable this you  
+simply have to set the property `<maven-buildtime-profiler-output>` with value `json`  
+under `<properties>` section in your project's pom.
+
+Additionally, you can set the property `<maven-buildtime-profiler-directory>` to indicate  
+the destination folder of the `report.json` file:
+
+```xml
+  <properties>
+    <maven-buildtime-profiler>json</maven-buildtime-profiler>
+    <maven-buildtime-profiler-output>${maven-buildtime-profiler}</maven-buildtime-profiler-output>
+    <maven-buildtime-profiler-directory>ignore/</maven-buildtime-profiler-directory>
+  </properties>
+```
+
+<small>Note that in this example we can also set the output mode adding `-Dmaven-buildtime-profiler=stdout`</small> to the maven command.
+
 Here's an example of what the output will look like:
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20190722</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -19,6 +19,7 @@ package com.soebes.maven.extensions;
  * under the License.
  */
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collections;
@@ -395,25 +396,33 @@ public class BuildTimeProfiler
 
     private void executionResultEventHandler( MavenExecutionResult event )
     {
-
         String output = event.getProject().getProperties().getProperty("maven-buildtime-profiler");
+        String filename = "";
+        String body = "";
 
         if (output != null)
         {
             switch (output.toLowerCase())
             {
                 case "json":
-                    try (FileWriter file = new FileWriter("report.json"))
-                    {
-                        file.write(toJSON().toString());
-                    } catch (IOException e) {
-                        LOGGER.error(e.getMessage());
-                    }
-                    return;
+                    body = toJSON().toString();
+                    filename = "report.json";
+                    break;
                 case "stdout":
                 default:
                     report(event);
                     return;
+            }
+
+            File dest = event.getProject().getProperties().containsKey("maven-buildtime-profiler-directory") ?
+                new File(event.getProject().getProperties().getProperty("maven-buildtime-profiler-directory"), filename) :
+                new File(event.getProject().getBasedir(), filename);
+
+            try (FileWriter file = new FileWriter(dest))
+            {
+                file.write(body);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
 

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -37,6 +37,7 @@ import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.RepositoryEvent.EventType;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -474,6 +475,25 @@ public class BuildTimeProfiler
 
         forkTimer.report();
         forkProject.report();
+    }
+
+    private JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        jsonObject.put("discoveryTime", discoveryTimer.getTime());
+        jsonObject.put("mojos", mojoTimer.toJSON());
+        jsonObject.put("goals", goalTimer.toJSON());
+        jsonObject.put("install", installTimer.toJSON());
+        jsonObject.put("download", downloadTimer.toJSON());
+        jsonObject.put("deploy", deployTimer.toJSON());
+        jsonObject.put("metadataInstall", metadataInstallTimer.toJSON());
+        jsonObject.put("metadataDownload", metadataDownloadTimer.toJSON());
+        jsonObject.put("metadataDeployment", metadataDeploymentTimer.toJSON());
+        jsonObject.put("forkTime", forkTimer.getTime());
+        jsonObject.put("forkProject", forkProject.toJSON());
+
+        return jsonObject;
     }
 
     private ProjectKey mavenProjectToProjectKey( MavenProject project )

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -421,6 +421,7 @@ public class BuildTimeProfiler
             try (FileWriter file = new FileWriter(dest))
             {
                 file.write(body);
+                return;
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -19,6 +19,8 @@ package com.soebes.maven.extensions;
  * under the License.
  */
 
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -394,6 +396,12 @@ public class BuildTimeProfiler
     private void executionResultEventHandler( MavenExecutionResult event )
     {
         report(event);
+
+        try (FileWriter file = new FileWriter("report.json")) {
+            file.write(toJSON().toString());
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage());
+        }
     }
 
     private void report(MavenExecutionResult event)
@@ -482,7 +490,7 @@ public class BuildTimeProfiler
         JSONObject jsonObject = new JSONObject();
 
         jsonObject.put("discoveryTime", discoveryTimer.getTime());
-        jsonObject.put("mojos", mojoTimer.toJSON());
+        jsonObject.put("build", mojoTimer.toJSON());
         jsonObject.put("goals", goalTimer.toJSON());
         jsonObject.put("install", installTimer.toJSON());
         jsonObject.put("download", downloadTimer.toJSON());

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -392,6 +392,11 @@ public class BuildTimeProfiler
 
     private void executionResultEventHandler( MavenExecutionResult event )
     {
+        report(event);
+    }
+
+    private void report(MavenExecutionResult event)
+    {
         orderLifeCycleOnPreparedOrder( lifeCyclePhases );
 
         LOGGER.debug( "MBTP: executionResultEventHandler: {}", event.getProject() );
@@ -445,7 +450,7 @@ public class BuildTimeProfiler
                 for ( Entry<ProjectMojo, SystemTime> pluginInPhase : plugisInPhase.entrySet() )
                 {
                     LOGGER.info( "{} ms: {}", String.format( "%8d", pluginInPhase.getValue().getElapsedTime() ),
-                                 pluginInPhase.getKey().getMojo().getFullId() );
+                        pluginInPhase.getKey().getMojo().getFullId() );
                 }
 
             }

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -395,13 +395,29 @@ public class BuildTimeProfiler
 
     private void executionResultEventHandler( MavenExecutionResult event )
     {
-        report(event);
 
-        try (FileWriter file = new FileWriter("report.json")) {
-            file.write(toJSON().toString());
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage());
+        String output = event.getProject().getProperties().getProperty("maven-buildtime-profiler");
+
+        if (output != null)
+        {
+            switch (output.toLowerCase())
+            {
+                case "json":
+                    try (FileWriter file = new FileWriter("report.json"))
+                    {
+                        file.write(toJSON().toString());
+                    } catch (IOException e) {
+                        LOGGER.error(e.getMessage());
+                    }
+                    return;
+                case "stdout":
+                default:
+                    report(event);
+                    return;
+            }
         }
+
+        report(event);
     }
 
     private void report(MavenExecutionResult event)

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -422,8 +422,11 @@ public class BuildTimeProfiler
             {
                 file.write(body);
                 return;
-            } catch (IOException e) {
-                e.printStackTrace();
+            }
+            catch (IOException e)
+            {
+                LOGGER.error("Couldn't write to file at {}: {}", dest, e.getMessage());
+                return;
             }
         }
 

--- a/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
+++ b/src/main/java/com/soebes/maven/extensions/BuildTimeProfiler.java
@@ -396,7 +396,7 @@ public class BuildTimeProfiler
 
     private void executionResultEventHandler( MavenExecutionResult event )
     {
-        String output = event.getProject().getProperties().getProperty("maven-buildtime-profiler");
+        String output = event.getProject().getProperties().getProperty("maven-buildtime-profiler-output");
         String filename = "";
         String body = "";
 

--- a/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
@@ -53,10 +53,8 @@ class DiscoveryTimer
         LOGGER.info( "------------------------------------------------------------------------" );
     }
 
-    public JSONObject toJSON()
+    public long getTime()
     {
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("discoveryTime", time.getElapsedTime());
-        return jsonObject;
+        return this.time.getElapsedTime();
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
@@ -19,6 +19,7 @@ package com.soebes.maven.extensions;
  * under the License.
  */
 
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,4 +53,9 @@ class DiscoveryTimer
         LOGGER.info( "------------------------------------------------------------------------" );
     }
 
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("discoveryTime", String.format( "%8d", time.getElapsedTime() ));
+        return jsonObject;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
@@ -56,7 +56,7 @@ class DiscoveryTimer
     public JSONObject toJSON()
     {
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("discoveryTime", String.format( "%8d", time.getElapsedTime() ));
+        jsonObject.put("discoveryTime", time.getElapsedTime());
         return jsonObject;
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/DiscoveryTimer.java
@@ -53,7 +53,8 @@ class DiscoveryTimer
         LOGGER.info( "------------------------------------------------------------------------" );
     }
 
-    public JSONObject toJSON() {
+    public JSONObject toJSON()
+    {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("discoveryTime", String.format( "%8d", time.getElapsedTime() ));
         return jsonObject;

--- a/src/main/java/com/soebes/maven/extensions/ForkTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/ForkTimer.java
@@ -53,4 +53,7 @@ class ForkTimer
         LOGGER.info( "ForkTime: {}", this.time.getElapsedTime() );
     }
 
+    public long getTime() {
+        return this.time.getElapsedTime();
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/GoalTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/GoalTimer.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,5 +66,10 @@ class GoalTimer
             LOGGER.info( "{} ms : {}", String.format( "%8d", item.getValue().getElapsedTime() ),
                          item.getKey().getId() );
         }
+    }
+
+    public JSONObject toJSON()
+    {
+
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/GoalTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/GoalTimer.java
@@ -70,6 +70,13 @@ class GoalTimer
 
     public JSONObject toJSON()
     {
+        JSONObject jsonObject = new JSONObject();
 
+        for ( Entry<ProjectGoal, SystemTime> item : this.timerEvents.entrySet() )
+        {
+            jsonObject.put(item.getKey().getId(), item.getValue().getElapsedTime());
+        }
+
+        return jsonObject;
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/MojoTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/MojoTimer.java
@@ -161,16 +161,13 @@ class MojoTimer
             // Projects section
 
             JSONObject artifactObject = projectObject.has(artifactId) ? projectObject.getJSONObject(artifactId) : new JSONObject();
-            long phaseResult = artifactObject.has(phase) ? (long) artifactObject.get(phase) : 0;
 
-            phaseResult += time;
-
-            artifactObject.put(phase, phaseResult);
+            artifactObject.put(phase, artifactObject.has(phase) ? (long) artifactObject.get(phase) + time : time);
             projectObject.put(artifactId, artifactObject);
 
             // Phases section
 
-            phaseObject.put(phase, phaseObject.has(phase) ? (long) phaseObject.get(phase) + phaseResult : phaseResult);
+            phaseObject.put(phase, phaseObject.has(phase) ? (long) phaseObject.get(phase) + time : time);
 
             // Plugins section
 

--- a/src/main/java/com/soebes/maven/extensions/MojoTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/MojoTimer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,5 +142,25 @@ class MojoTimer
         {
             LOGGER.info( "{} : {}", item.getKey().getId(), item.getValue().getElapsedTime() );
         }
+    }
+
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+
+        for ( Entry<ProjectMojo, SystemTime> item : this.timerEvents.entrySet() )
+        {
+            String artifactId = item.getKey().getProject().getArtifactId();
+            String phase = item.getKey().getMojo().getPhase();
+
+            JSONObject artifactObject = jsonObject.has(artifactId) ? jsonObject.getJSONObject(artifactId) : new JSONObject();
+            long phaseResult = artifactObject.has(phase) ? (long) artifactObject.get(phase) : 0;
+
+            phaseResult += item.getValue().getElapsedTime();
+
+            artifactObject.put(phase, phaseResult);
+            jsonObject.put(artifactId, artifactObject);
+        }
+
+        return jsonObject;
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/MojoTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/MojoTimer.java
@@ -147,6 +147,9 @@ class MojoTimer
     public JSONObject toJSON()
     {
         JSONObject jsonObject = new JSONObject();
+        JSONObject projectObject = new JSONObject();
+        JSONObject phaseObject = new JSONObject();
+        JSONObject pluginsObject = new JSONObject();
 
         for ( Entry<ProjectMojo, SystemTime> item : this.timerEvents.entrySet() )
         {
@@ -159,8 +162,19 @@ class MojoTimer
             phaseResult += item.getValue().getElapsedTime();
 
             artifactObject.put(phase, phaseResult);
-            jsonObject.put(artifactId, artifactObject);
+            projectObject.put(artifactId, artifactObject);
+
+            phaseObject.put(phase, phaseObject.has(phase) ? (long) phaseObject.get(phase) + phaseResult : phaseResult);
+
+            if (!pluginsObject.has(phase))
+                pluginsObject.put(phase, new JSONObject());
+
+            ((JSONObject) pluginsObject.get(phase)).put(item.getKey().getMojo().getFullId(), item.getValue().getElapsedTime());
         }
+
+        jsonObject.put("projects", projectObject);
+        jsonObject.put("phases", phaseObject);
+        jsonObject.put("plugins", pluginsObject);
 
         return jsonObject;
     }

--- a/src/main/java/com/soebes/maven/extensions/MojoTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/MojoTimer.java
@@ -144,7 +144,8 @@ class MojoTimer
         }
     }
 
-    public JSONObject toJSON() {
+    public JSONObject toJSON()
+    {
         JSONObject jsonObject = new JSONObject();
 
         for ( Entry<ProjectMojo, SystemTime> item : this.timerEvents.entrySet() )

--- a/src/main/java/com/soebes/maven/extensions/MojoTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/MojoTimer.java
@@ -155,21 +155,34 @@ class MojoTimer
         {
             String artifactId = item.getKey().getProject().getArtifactId();
             String phase = item.getKey().getMojo().getPhase();
+            String plugin = item.getKey().getMojo().getFullId();
+            long time = item.getValue().getElapsedTime();
 
-            JSONObject artifactObject = jsonObject.has(artifactId) ? jsonObject.getJSONObject(artifactId) : new JSONObject();
+            // Projects section
+
+            JSONObject artifactObject = projectObject.has(artifactId) ? projectObject.getJSONObject(artifactId) : new JSONObject();
             long phaseResult = artifactObject.has(phase) ? (long) artifactObject.get(phase) : 0;
 
-            phaseResult += item.getValue().getElapsedTime();
+            phaseResult += time;
 
             artifactObject.put(phase, phaseResult);
             projectObject.put(artifactId, artifactObject);
 
+            // Phases section
+
             phaseObject.put(phase, phaseObject.has(phase) ? (long) phaseObject.get(phase) + phaseResult : phaseResult);
+
+            // Plugins section
 
             if (!pluginsObject.has(phase))
                 pluginsObject.put(phase, new JSONObject());
 
-            ((JSONObject) pluginsObject.get(phase)).put(item.getKey().getMojo().getFullId(), item.getValue().getElapsedTime());
+            long pluginResult = ((JSONObject) pluginsObject.get(phase)).has(plugin) ?
+                (long) ((JSONObject) pluginsObject.get(phase)).get(plugin) : 0;
+
+            pluginResult += time;
+
+            ((JSONObject) pluginsObject.get(phase)).put(plugin, pluginResult);
         }
 
         jsonObject.put("projects", projectObject);

--- a/src/main/java/com/soebes/maven/extensions/ProjectTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/ProjectTimer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.project.MavenProject;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,5 +80,17 @@ class ProjectTimer
         {
             LOGGER.info( "ProjectTimer: {} : {}", item.getKey(), item.getValue().getElapsedTime() );
         }
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        for ( Entry<String, SystemTime> item : this.timerEvents.entrySet() )
+        {
+            jsonObject.put(item.getKey(), item.getValue().getElapsedTime());
+        }
+
+        return jsonObject;
     }
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/AbstractArtifactTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/AbstractArtifactTimer.java
@@ -123,7 +123,7 @@ public abstract class AbstractArtifactTimer
 
         jsonObject.put("time", totalInstallationTime);
         jsonObject.put("size", totalInstallationSize);
-        jsonObject.put("rate", mibPerSeconds);
+        jsonObject.put("rate", ("" + mibPerSeconds).equals("NaN") ? null : mibPerSeconds);
 
         return jsonObject;
     }

--- a/src/main/java/com/soebes/maven/extensions/artifact/AbstractArtifactTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/AbstractArtifactTimer.java
@@ -20,10 +20,12 @@ package com.soebes.maven.extensions.artifact;
  */
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.artifact.Artifact;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,4 +100,31 @@ public abstract class AbstractArtifactTimer
         return (double) sizeInBytes / dividerTime / MiB;
     }
 
+    public JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
+        }
+
+        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
+
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+        jsonObject.put("rate", mibPerSeconds);
+
+        return jsonObject;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/DeployTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/DeployTimer.java
@@ -61,33 +61,4 @@ public class DeployTimer
                      NumberFormat.getNumberInstance().format( mibPerSeconds ) );
         LOGGER.info( "------------------------------------------------------------------------" );
     }
-
-    public JSONObject toJSON()
-    {
-        JSONObject jsonObject = new JSONObject();
-
-        long totalInstallationTime = 0;
-        long totalInstallationSize = 0;
-
-        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
-        {
-            totalInstallationTime += item.getValue().getElapsedTime();
-            totalInstallationSize += item.getValue().getSize();
-
-            JSONObject jsonItem = new JSONObject();
-            jsonItem.put("time", item.getValue().getElapsedTime());
-            jsonItem.put("size", item.getValue().getSize());
-
-            jsonObject.put(item.getKey(), jsonItem);
-        }
-
-        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
-
-        jsonObject.put("time", totalInstallationTime);
-        jsonObject.put("size", totalInstallationSize);
-        jsonObject.put("rate", mibPerSeconds);
-
-        return jsonObject;
-    }
-
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/DeployTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/DeployTimer.java
@@ -21,7 +21,7 @@ package com.soebes.maven.extensions.artifact;
 
 import java.text.NumberFormat;
 import java.util.Map.Entry;
-
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +60,34 @@ public class DeployTimer
                      NumberFormat.getIntegerInstance().format( totalInstallationSize ),
                      NumberFormat.getNumberInstance().format( mibPerSeconds ) );
         LOGGER.info( "------------------------------------------------------------------------" );
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
+        }
+
+        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
+
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+        jsonObject.put("rate", mibPerSeconds);
+
+        return jsonObject;
     }
 
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/DownloadTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/DownloadTimer.java
@@ -21,7 +21,7 @@ package com.soebes.maven.extensions.artifact;
 
 import java.text.NumberFormat;
 import java.util.Map.Entry;
-
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,4 +63,31 @@ public class DownloadTimer
 
     }
 
+    public JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
+        }
+
+        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
+
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+        jsonObject.put("rate", mibPerSeconds);
+
+        return jsonObject;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/DownloadTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/DownloadTimer.java
@@ -62,32 +62,4 @@ public class DownloadTimer
                      NumberFormat.getNumberInstance().format( mibPerSeconds ) );
 
     }
-
-    public JSONObject toJSON()
-    {
-        JSONObject jsonObject = new JSONObject();
-
-        long totalInstallationTime = 0;
-        long totalInstallationSize = 0;
-
-        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
-        {
-            totalInstallationTime += item.getValue().getElapsedTime();
-            totalInstallationSize += item.getValue().getSize();
-
-            JSONObject jsonItem = new JSONObject();
-            jsonItem.put("time", item.getValue().getElapsedTime());
-            jsonItem.put("size", item.getValue().getSize());
-
-            jsonObject.put(item.getKey(), jsonItem);
-        }
-
-        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
-
-        jsonObject.put("time", totalInstallationTime);
-        jsonObject.put("size", totalInstallationSize);
-        jsonObject.put("rate", mibPerSeconds);
-
-        return jsonObject;
-    }
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
@@ -62,33 +62,4 @@ public class InstallTimer
                      NumberFormat.getNumberInstance().format( mibPerSeconds ) );
         LOGGER.info( "------------------------------------------------------------------------" );
     }
-
-    public JSONObject toJSON()
-    {
-        JSONObject jsonObject = new JSONObject();
-
-        long totalInstallationTime = 0;
-        long totalInstallationSize = 0;
-
-        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
-        {
-            totalInstallationTime += item.getValue().getElapsedTime();
-            totalInstallationSize += item.getValue().getSize();
-
-            JSONObject jsonItem = new JSONObject();
-            jsonItem.put("time", item.getValue().getElapsedTime());
-            jsonItem.put("size", item.getValue().getSize());
-
-            jsonObject.put(item.getKey(), jsonItem);
-        }
-
-        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
-
-        jsonObject.put("time", totalInstallationTime);
-        jsonObject.put("size", totalInstallationSize);
-        jsonObject.put("rate", mibPerSeconds);
-
-        return jsonObject;
-    }
-
 }

--- a/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
@@ -75,14 +75,18 @@ public class InstallTimer
             totalInstallationTime += item.getValue().getElapsedTime();
             totalInstallationSize += item.getValue().getSize();
 
-            jsonObject.put(item.getKey(), item.getValue().getElapsedTime());
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
         }
 
         double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
 
-        jsonObject.put("installaionTime", totalInstallationTime);
-        jsonObject.put("installaionSize", totalInstallationSize);
-        jsonObject.put("installaionRate", mibPerSeconds);
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+        jsonObject.put("rate", mibPerSeconds);
 
         return jsonObject;
     }

--- a/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/artifact/InstallTimer.java
@@ -21,7 +21,7 @@ package com.soebes.maven.extensions.artifact;
 
 import java.text.NumberFormat;
 import java.util.Map.Entry;
-
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +61,30 @@ public class InstallTimer
                      NumberFormat.getIntegerInstance().format( totalInstallationSize ),
                      NumberFormat.getNumberInstance().format( mibPerSeconds ) );
         LOGGER.info( "------------------------------------------------------------------------" );
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            jsonObject.put(item.getKey(), item.getValue().getElapsedTime());
+        }
+
+        double mibPerSeconds = calculateMegabytesPerSeconds( totalInstallationTime, totalInstallationSize );
+
+        jsonObject.put("installaionTime", totalInstallationTime);
+        jsonObject.put("installaionSize", totalInstallationSize);
+        jsonObject.put("installaionRate", mibPerSeconds);
+
+        return jsonObject;
     }
 
 }

--- a/src/main/java/com/soebes/maven/extensions/metadata/AbstractMetadataTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/metadata/AbstractMetadataTimer.java
@@ -20,12 +20,14 @@ package com.soebes.maven.extensions.metadata;
  */
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.aether.RepositoryEvent;
 import org.eclipse.aether.metadata.Metadata;
 
 import com.soebes.maven.extensions.TimePlusSize;
+import org.json.JSONObject;
 
 /**
  * @author Karl Heinz Marbaise <a href="mailto:kama@soebes.de">kama@soebes.de</a>
@@ -81,4 +83,27 @@ public abstract class AbstractMetadataTimer
         getTimerEvents().get( metadataId ).setSize( size );
     }
 
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
+        }
+
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+
+        return jsonObject;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/metadata/MetadataInstallTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/metadata/MetadataInstallTimer.java
@@ -21,7 +21,7 @@ package com.soebes.maven.extensions.metadata;
 
 import java.text.NumberFormat;
 import java.util.Map.Entry;
-
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,4 +62,27 @@ public class MetadataInstallTimer
         LOGGER.info( "------------------------------------------------------------------------" );
     }
 
+    public JSONObject toJSON() {
+        JSONObject jsonObject = new JSONObject();
+
+        long totalInstallationTime = 0;
+        long totalInstallationSize = 0;
+
+        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
+        {
+            totalInstallationTime += item.getValue().getElapsedTime();
+            totalInstallationSize += item.getValue().getSize();
+
+            JSONObject jsonItem = new JSONObject();
+            jsonItem.put("time", item.getValue().getElapsedTime());
+            jsonItem.put("size", item.getValue().getSize());
+
+            jsonObject.put(item.getKey(), jsonItem);
+        }
+
+        jsonObject.put("time", totalInstallationTime);
+        jsonObject.put("size", totalInstallationSize);
+
+        return jsonObject;
+    }
 }

--- a/src/main/java/com/soebes/maven/extensions/metadata/MetadataInstallTimer.java
+++ b/src/main/java/com/soebes/maven/extensions/metadata/MetadataInstallTimer.java
@@ -61,28 +61,4 @@ public class MetadataInstallTimer
         // NumberFormat.getIntegerInstance().format( totalInstallationSize ) );
         LOGGER.info( "------------------------------------------------------------------------" );
     }
-
-    public JSONObject toJSON() {
-        JSONObject jsonObject = new JSONObject();
-
-        long totalInstallationTime = 0;
-        long totalInstallationSize = 0;
-
-        for ( Entry<String, TimePlusSize> item : this.getTimerEvents().entrySet() )
-        {
-            totalInstallationTime += item.getValue().getElapsedTime();
-            totalInstallationSize += item.getValue().getSize();
-
-            JSONObject jsonItem = new JSONObject();
-            jsonItem.put("time", item.getValue().getElapsedTime());
-            jsonItem.put("size", item.getValue().getSize());
-
-            jsonObject.put(item.getKey(), jsonItem);
-        }
-
-        jsonObject.put("time", totalInstallationTime);
-        jsonObject.put("size", totalInstallationSize);
-
-        return jsonObject;
-    }
 }


### PR DESCRIPTION
# Motivation

As discussed in #5 , the purpose of this PR is to make the extension configurable in order to select wether to print the report via stdout or to a JSON file.  

# Plan

This feature accepts 2 maven properties:

- `<maven-buildtime-profiler-output>`: optional, used to select between `stdout` or `json` output.
- `<maven-buildtime-profiler-directory>`: optional, used to select the destination folder of the `report.json` file

By default, the extension works as before, printing the output to the console. If json output is set, the default destination folder is the project's base directory.

An example of the output would be:

```json
{
  "forkTime": 0,
  "forkProject": {},
  "download": {
    "size": 0,
    "time": 0
  },
  "build": {
    "projects": {
      "maven-buildtime-profiler": {
        "package": 2202,
        "test": 6845,
        "clean": 351,
        "test-compile": 599,
        "process-test-resources": 15,
        "compile": 1736,
        "pre-integration-test": 905,
        "install": 140,
        "post-integration-test": 117,
        "verify": 454,
        "process-classes": 263,
        "process-resources": 174,
        "initialize": 678,
        "generate-sources": 271,
        "validate": 383
      }
    },
    "plugins": {
      "package": {
        "org.apache.maven.plugins:maven-site-plugin:3.7.1:attach-descriptor (attach-descriptor)": 1411,
        "org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (default)": 376,
        "org.apache.maven.plugins:maven-jar-plugin:3.1.0:jar (default-jar)": 415
      },
      "test": {
        "org.apache.maven.plugins:maven-surefire-plugin:2.22.0:test (default-test)": 6845
      },
      "clean": {
        "org.apache.maven.plugins:maven-clean-plugin:3.1.0:clean (default-clean)": 351
      },
      "test-compile": {
        "org.apache.maven.plugins:maven-compiler-plugin:3.8.0:testCompile (default-testCompile)": 599
      },
      "process-test-resources": {
        "org.apache.maven.plugins:maven-resources-plugin:3.1.0:testResources (default-testResources)": 15
      },
      "compile": {
        "org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile)": 1736
      },
      "pre-integration-test": {
        "org.codehaus.mojo:mrm-maven-plugin:1.1.0:start (default)": 905
      },
      "install": {
        "org.apache.maven.plugins:maven-install-plugin:2.5.2:install (default-install)": 140
      },
      "post-integration-test": {
        "org.codehaus.mojo:mrm-maven-plugin:1.1.0:stop (default)": 117
      },
      "verify": {
        "org.jacoco:jacoco-maven-plugin:0.8.1:report (default)": 454
      },
      "process-classes": {
        "org.sonatype.plugins:sisu-maven-plugin:1.1:main-index (generate-index)": 263
      },
      "process-resources": {
        "org.apache.maven.plugins:maven-resources-plugin:3.1.0:resources (default-resources)": 174
      },
      "initialize": {
        "org.jacoco:jacoco-maven-plugin:0.8.1:prepare-agent (default)": 678
      },
      "generate-sources": {
        "org.codehaus.mojo:templating-maven-plugin:1.0.0:filter-sources (default)": 271
      },
      "validate": {
        "org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce (enforce-maven)": 383
      }
    },
    "phases": {
      "package": 2202,
      "test": 6845,
      "clean": 351,
      "test-compile": 599,
      "process-test-resources": 15,
      "compile": 1736,
      "pre-integration-test": 905,
      "install": 140,
      "post-integration-test": 117,
      "verify": 454,
      "process-classes": 263,
      "process-resources": 174,
      "initialize": 678,
      "generate-sources": 271,
      "validate": 383
    }
  },
  "install": {
    "size": 183511,
    "com.soebes.maven.extensions:maven-buildtime-profiler:0.2.1-SNAPSHOT:jar": {
      "size": 46322,
      "time": 21
    },
    "rate": 3.723611222936752,
    "com.soebes.maven.extensions:maven-buildtime-profiler:0.2.1-SNAPSHOT:pom": {
      "size": 10842,
      "time": 11
    },
    "com.soebes.maven.extensions:maven-buildtime-profiler:0.2.1-SNAPSHOT:mvn311:jar": {
      "size": 126347,
      "time": 15
    },
    "time": 47
  },
  "metadataInstall": {
    "com.soebes.maven.extensions:maven-buildtime-profiler:0.2.1-SNAPSHOT:maven-metadata.xml:SNAPSHOT": {
      "size": 0,
      "time": 1
    },
    "size": 0,
    "com.soebes.maven.extensions:maven-buildtime-profiler::maven-metadata.xml:RELEASE_OR_SNAPSHOT": {
      "size": 0,
      "time": 1
    },
    "time": 2
  },
  "metadataDeployment": {
    "size": 0,
    "time": 0
  },
  "discoveryTime": 137,
  "goals": {},
  "deploy": {
    "size": 0,
    "time": 0
  },
  "metadataDownload": {
    "size": 0,
    "time": 0
  }
}
```

Note that te units are the same as the original report: milliseconds for time, mebibytes per second for rate and bytes for sizes.

# Acceptance criteria

- Output mode is selectable between `json` and `stdout`, being `stdout` the default one
- Destination folder is configurable
- Tests pass successfully