### PR TITLE
Updated JDK versions according to the current Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # give to fix timeout issues temporarily (hint by travis support.)
 sudo: required
+dist: xenial
 language: java
 jdk:
-  - openjdk7
-  - oraclejdk8
+  - openjdk8
   - openjdk9
   - openjdk10
 


### PR DESCRIPTION
[JVM support at Travis](https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support).