### PR TITLE
Update the extensions schema used in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ If you like to use this extension for Maven 3.3.1+ you
 have to define the following `.mvn/extensions.xml` file:
 
 ``` xml
-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 http://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
   <extension>
     <groupId>com.soebes.maven.extensions</groupId>
     <artifactId>maven-buildtime-profiler</artifactId>


### PR DESCRIPTION
IntelliJ flags the contents of the extensions.xml file as an error unless I upgrade the extensions schema from version 1.0.0 to 1.1.0. I think this is because `xmlns` and `schemaLocation` both refer to version 1.1.0 but then link to version 1.0.0 of the xsd file.

The pull request fixes this.